### PR TITLE
Modernize repo path in list-all

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-github_coordinates=k14s/ytt
+github_coordinates=carvel-dev/ytt
 releases_path="https://api.github.com/repos/${github_coordinates}/releases"
 cmd="curl -s"
 if [ -n "$GITHUB_API_TOKEN" ]; then


### PR DESCRIPTION
The old repo path redirects to the new one, but this is a tricky thing to notice. Update.